### PR TITLE
convert T::Structs to bare Ruby objects

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -29,6 +29,13 @@ Sorbet/StrictSigil:
     - "test/*"
     - ".toys/**/*"
 
+Sorbet/ForbidTStruct:
+  Enabled: true
+  # Context for why this is preferable https://github.com/Shopify/rubocop-sorbet/pull/178#issuecomment-1739924189
+
+Sorbet/RedundantExtendTSig:
+  Enabled: true
+
 Minitest:
   Enabled: true
 

--- a/lib/lunchmoney/api.rb
+++ b/lib/lunchmoney/api.rb
@@ -5,6 +5,7 @@ require_relative "exceptions"
 require_relative "config"
 
 require_relative "api_call"
+require_relative "data_object"
 require_relative "user/user_calls"
 require_relative "categories/category_calls"
 require_relative "tags/tag_calls"

--- a/lib/lunchmoney/assets/asset.rb
+++ b/lib/lunchmoney/assets/asset.rb
@@ -2,18 +2,50 @@
 # frozen_string_literal: true
 
 module LunchMoney
-  class Asset < T::Struct
-    prop :id, Integer
-    prop :type_name, String
-    prop :subtype_name, T.nilable(String)
-    prop :name, String
-    prop :display_name, T.nilable(String)
-    prop :balance, String
-    prop :balance_as_of, String
-    prop :closed_on, T.nilable(String)
-    prop :currency, String
-    prop :institution_name, T.nilable(String)
-    prop :exclude_transactions, T::Boolean
-    prop :created_at, String
+  class Asset < LunchMoney::DataObject
+    sig { returns(Integer) }
+    attr_accessor :id
+
+    sig { returns(String) }
+    attr_accessor :type_name, :name, :balance, :balance_as_of, :currency, :created_at
+
+    sig { returns(T.nilable(String)) }
+    attr_accessor :subtype_name, :display_name, :closed_on, :institution_name
+
+    sig { returns(T::Boolean) }
+    attr_accessor :exclude_transactions
+
+    sig do
+      params(
+        created_at: String,
+        type_name: String,
+        name: String,
+        balance: String,
+        balance_as_of: String,
+        currency: String,
+        exclude_transactions: T::Boolean,
+        id: Integer,
+        subtype_name: T.nilable(String),
+        display_name: T.nilable(String),
+        closed_on: T.nilable(String),
+        institution_name: T.nilable(String),
+      ).void
+    end
+    def initialize(created_at:, type_name:, name:, balance:, balance_as_of:, currency:, exclude_transactions:, id:,
+      subtype_name: nil, display_name: nil, closed_on: nil, institution_name: nil)
+      super()
+      @created_at = created_at
+      @type_name = type_name
+      @name = name
+      @balance = balance
+      @balance_as_of = balance_as_of
+      @currency = currency
+      @exclude_transactions = exclude_transactions
+      @id = id
+      @subtype_name = subtype_name
+      @display_name = display_name
+      @closed_on = closed_on
+      @institution_name = institution_name
+    end
   end
 end

--- a/lib/lunchmoney/assets/asset_calls.rb
+++ b/lib/lunchmoney/assets/asset_calls.rb
@@ -13,7 +13,7 @@ module LunchMoney
       return api_errors if api_errors.present?
 
       response.body[:assets].map do |asset|
-        LunchMoney::Asset.new(asset)
+        LunchMoney::Asset.new(**asset)
       end
     end
 
@@ -51,7 +51,7 @@ module LunchMoney
       api_errors = errors(response)
       return api_errors if api_errors.present?
 
-      LunchMoney::Asset.new(response.body)
+      LunchMoney::Asset.new(**response.body)
     end
 
     sig do
@@ -89,7 +89,7 @@ module LunchMoney
       api_errors = errors(response)
       return api_errors if api_errors.present?
 
-      LunchMoney::Asset.new(response.body)
+      LunchMoney::Asset.new(**response.body)
     end
   end
 end

--- a/lib/lunchmoney/budget/budget.rb
+++ b/lib/lunchmoney/budget/budget.rb
@@ -4,16 +4,59 @@
 require_relative "data"
 
 module LunchMoney
-  class Budget < T::Struct
-    prop :category_name, String
-    prop :category_id, Integer
-    prop :category_group_name, T.nilable(String)
-    prop :group_id, T.nilable(Integer)
-    prop :is_group, T.nilable(T::Boolean)
-    prop :is_income, T::Boolean
-    prop :exclude_from_budget, T::Boolean
-    prop :exclude_from_totals, T::Boolean
-    prop :data, T::Hash[Symbol, LunchMoney::Data]
-    prop :config, T::Hash[T.untyped, T.untyped] # TODO: this needs to be better typed
+  class Budget < LunchMoney::DataObject
+    sig { returns(String) }
+    attr_accessor :category_name
+
+    sig { returns(Integer) }
+    attr_accessor :category_id
+
+    sig { returns(T.nilable(String)) }
+    attr_accessor :category_group_name
+
+    sig { returns(T.nilable(Integer)) }
+    attr_accessor :group_id
+
+    sig { returns(T.nilable(T::Boolean)) }
+    attr_accessor :is_group
+
+    sig { returns(T::Boolean) }
+    attr_accessor :is_income, :exclude_from_budget, :exclude_from_totals
+
+    sig { returns(T::Hash[Symbol, LunchMoney::Data]) }
+    attr_accessor :data
+
+    # TODO: this needs to be better typed
+    sig { returns(T::Hash[T.untyped, T.untyped]) }
+    attr_accessor :config
+
+    sig do
+      params(
+        config: T::Hash[T.untyped, T.untyped],
+        category_id: Integer,
+        is_income: T::Boolean,
+        exclude_from_budget: T::Boolean,
+        exclude_from_totals: T::Boolean,
+        data: T::Hash[Symbol, LunchMoney::Data],
+        category_name: String,
+        category_group_name: T.nilable(String),
+        group_id: T.nilable(Integer),
+        is_group: T.nilable(T::Boolean),
+      ).void
+    end
+    def initialize(config:, category_id:, is_income:, exclude_from_budget:, exclude_from_totals:, data:,
+      category_name:, category_group_name: nil, group_id: nil, is_group: nil)
+      super()
+      @config = config
+      @category_id = category_id
+      @is_income = is_income
+      @exclude_from_budget = exclude_from_budget
+      @exclude_from_totals = exclude_from_totals
+      @data = data
+      @category_name = category_name
+      @category_group_name = category_group_name
+      @group_id = group_id
+      @is_group = is_group
+    end
   end
 end

--- a/lib/lunchmoney/budget/budget_calls.rb
+++ b/lib/lunchmoney/budget/budget_calls.rb
@@ -28,7 +28,7 @@ module LunchMoney
       response.body.map do |budget|
         # budget[:data] TODO: Add mapping to data object
 
-        LunchMoney::Budget.new(budget)
+        LunchMoney::Budget.new(**budget)
       end
     end
 

--- a/lib/lunchmoney/budget/data.rb
+++ b/lib/lunchmoney/budget/data.rb
@@ -2,12 +2,35 @@
 # frozen_string_literal: true
 
 module LunchMoney
-  class Data < T::Struct
-    prop :budget_amount, T.nilable(Integer)
-    prop :budget_currency, T.nilable(String)
-    prop :budget_to_base, T.nilable(Integer)
-    prop :spending_to_base, T.nilable(Integer)
-    prop :num_transactions, T.nilable(Integer)
-    prop :is_automated, T.nilable(T::Boolean), default: false
+  class Data < LunchMoney::DataObject
+    sig { returns(T.nilable(Integer)) }
+    attr_accessor :budget_amount, :budget_to_base, :spending_to_base, :num_transactions
+
+    sig { returns(T.nilable(String)) }
+    attr_accessor :budget_currency
+
+    sig { returns(T.nilable(T::Boolean)) }
+    attr_accessor :is_automated
+
+    sig do
+      params(
+        budget_amount: T.nilable(Integer),
+        budget_currency: T.nilable(String),
+        budget_to_base: T.nilable(Integer),
+        spending_to_base: T.nilable(Integer),
+        num_transactions: T.nilable(Integer),
+        is_automated: T.nilable(T::Boolean),
+      ).void
+    end
+    def initialize(budget_amount: nil, budget_currency: nil, budget_to_base: nil, spending_to_base: nil,
+      num_transactions: nil, is_automated: nil)
+      super()
+      @budget_amount = budget_amount
+      @budget_currency = budget_currency
+      @budget_to_base = budget_to_base
+      @spending_to_base = spending_to_base
+      @num_transactions = num_transactions
+      @is_automated = is_automated
+    end
   end
 end

--- a/lib/lunchmoney/categories/category.rb
+++ b/lib/lunchmoney/categories/category.rb
@@ -2,19 +2,58 @@
 # frozen_string_literal: true
 
 module LunchMoney
-  class Category < T::Struct
-    prop :id, Integer
-    prop :name, String
-    prop :description, T.nilable(String)
-    prop :is_income, T::Boolean, default: false
-    prop :exclude_from_budget, T::Boolean, default: false
-    prop :exclude_from_totals, T::Boolean, default: false
-    prop :archived, T::Boolean, default: false
-    prop :archived_on, T.nilable(String)
-    prop :updated_at, T.nilable(String)
-    prop :created_at, T.nilable(String)
-    prop :is_group, T::Boolean, default: false
-    prop :group_id, T.nilable(Integer)
-    prop :children, T::Array[LunchMoney::Category], default: []
+  class Category < LunchMoney::DataObject
+    sig { returns(Integer) }
+    attr_accessor :id
+
+    sig { returns(String) }
+    attr_accessor :name
+
+    sig { returns(T.nilable(String)) }
+    attr_accessor :description, :archived_on, :updated_at, :created_at
+
+    sig { returns(T::Boolean) }
+    attr_accessor :is_income, :exclude_from_budget, :exclude_from_totals, :archived, :is_group
+
+    sig { returns(T.nilable(Integer)) }
+    attr_accessor :group_id
+
+    sig { returns(T::Array[LunchMoney::Category]) }
+    attr_accessor :children
+
+    sig do
+      params(
+        name: String,
+        id: Integer,
+        children: T::Array[LunchMoney::Category],
+        is_income: T::Boolean,
+        exclude_from_budget: T::Boolean,
+        exclude_from_totals: T::Boolean,
+        archived: T::Boolean,
+        is_group: T::Boolean,
+        archived_on: T.nilable(String),
+        updated_at: T.nilable(String),
+        created_at: T.nilable(String),
+        group_id: T.nilable(Integer),
+        description: T.nilable(String),
+      ).void
+    end
+    def initialize(name:, id:, children:, is_income:, exclude_from_budget:, exclude_from_totals:, archived:, is_group:,
+      archived_on: nil, updated_at: nil, created_at: nil, group_id: nil, description: nil)
+      super()
+      @name = name
+      @id = id
+      @children = children
+      @is_income = is_income
+      @exclude_from_budget = exclude_from_budget
+      @exclude_from_totals = exclude_from_totals
+      @archived = archived
+      @is_group = is_group
+      @archived_on = archived_on
+      @updated_at = updated_at
+      @created_at = created_at
+      @group_id = group_id
+      @description = description
+    end
   end
 end

--- a/lib/lunchmoney/categories/category_calls.rb
+++ b/lib/lunchmoney/categories/category_calls.rb
@@ -14,9 +14,9 @@ module LunchMoney
       return api_errors if api_errors.present?
 
       response.body[:categories].map do |category|
-        category[:children]&.map! { |child_category| LunchMoney::Category.new(child_category) }
+        category[:children]&.map! { |child_category| LunchMoney::Category.new(**child_category) }
 
-        LunchMoney::Category.new(category)
+        LunchMoney::Category.new(**category)
       end
     end
 
@@ -27,9 +27,9 @@ module LunchMoney
       api_errors = errors(response)
       return api_errors if api_errors.present?
 
-      response.body[:children].map! { |child_category| LunchMoney::Category.new(child_category) }
+      response.body[:children].map! { |child_category| LunchMoney::Category.new(**child_category) }
 
-      LunchMoney::Category.new(response.body)
+      LunchMoney::Category.new(**response.body)
     end
 
     sig do
@@ -149,7 +149,7 @@ module LunchMoney
       api_errors = errors(response)
       return api_errors if api_errors.present?
 
-      LunchMoney::Category.new(response.body)
+      LunchMoney::Category.new(**response.body)
     end
 
     sig { params(category_id: Integer).returns(T.any(T::Boolean, LunchMoney::Errors)) }

--- a/lib/lunchmoney/crypto/crypto.rb
+++ b/lib/lunchmoney/crypto/crypto.rb
@@ -2,17 +2,45 @@
 # frozen_string_literal: true
 
 module LunchMoney
-  class Crypto < T::Struct
-    prop :id, T.nilable(Integer)
-    prop :zabo_account_id, T.nilable(Integer)
-    prop :source, String
-    prop :name, String
-    prop :display_name, T.nilable(String)
-    prop :balance, String
-    prop :balance_as_of, String
-    prop :currency, String
-    prop :status, String
-    prop :institution_name, String
-    prop :created_at, String
+  class Crypto < LunchMoney::DataObject
+    sig { returns(T.nilable(Integer)) }
+    attr_accessor :id, :zabo_account_id
+
+    sig { returns(String) }
+    attr_accessor :source, :name, :balance, :balance_as_of, :currency, :status, :institution_name, :created_at
+
+    sig { returns(T.nilable(String)) }
+    attr_accessor :display_name
+
+    sig do
+      params(
+        created_at: String,
+        source: String,
+        name: String,
+        balance: String,
+        balance_as_of: String,
+        currency: String,
+        status: String,
+        institution_name: String,
+        id: T.nilable(Integer),
+        zabo_account_id: T.nilable(Integer),
+        display_name: T.nilable(String),
+      ).void
+    end
+    def initialize(created_at:, source:, name:, balance:, balance_as_of:, currency:,
+      status:, institution_name:, id: nil, zabo_account_id: nil, display_name: nil)
+      super()
+      @created_at = created_at
+      @source = source
+      @name = name
+      @balance = balance
+      @balance_as_of = balance_as_of
+      @currency = currency
+      @status = status
+      @institution_name = institution_name
+      @id = id
+      @zabo_account_id = zabo_account_id
+      @display_name = display_name
+    end
   end
 end

--- a/lib/lunchmoney/crypto/crypto_calls.rb
+++ b/lib/lunchmoney/crypto/crypto_calls.rb
@@ -13,7 +13,7 @@ module LunchMoney
       return api_errors if api_errors.present?
 
       response.body[:crypto].map do |crypto|
-        LunchMoney::Crypto.new(crypto)
+        LunchMoney::Crypto.new(**crypto)
       end
     end
 
@@ -41,7 +41,7 @@ module LunchMoney
       api_errors = errors(response)
       return api_errors if api_errors.present?
 
-      LunchMoney::Crypto.new(response.body)
+      LunchMoney::Crypto.new(**response.body)
     end
   end
 end

--- a/lib/lunchmoney/data_object.rb
+++ b/lib/lunchmoney/data_object.rb
@@ -1,0 +1,26 @@
+# typed: strict
+# frozen_string_literal: true
+
+module LunchMoney
+  class DataObject
+    require "pry"
+
+    sig { params(symbolize_keys: T::Boolean).returns(T::Hash[String, T.untyped]) }
+    def serialize(symbolize_keys: false)
+      ivars = instance_variables
+
+      output = {}
+
+      ivars.each do |ivar|
+        key = ivar.to_s.gsub("@", "")
+        key = key.to_sym if symbolize_keys
+
+        value = instance_variable_get(ivar)
+
+        output[key] = value
+      end
+
+      output
+    end
+  end
+end

--- a/lib/lunchmoney/error.rb
+++ b/lib/lunchmoney/error.rb
@@ -2,8 +2,14 @@
 # frozen_string_literal: true
 
 module LunchMoney
-  class Error < T::Struct
-    const :message, String
+  class Error
+    sig { returns(String) }
+    attr_reader :message
+
+    sig { params(message: String).void }
+    def initialize(message:)
+      @message = message
+    end
   end
 end
 

--- a/lib/lunchmoney/plaid_accounts/plaid_account.rb
+++ b/lib/lunchmoney/plaid_accounts/plaid_account.rb
@@ -2,19 +2,61 @@
 # frozen_string_literal: true
 
 module LunchMoney
-  class PlaidAccount < T::Struct
-    prop :id, Integer
-    prop :date_linked, String
-    prop :name, String
-    prop :type, String
-    prop :subtype, T.nilable(String)
-    prop :mask, String
-    prop :institution_name, String
-    prop :status, String
-    prop :last_import, String
-    prop :balance, String
-    prop :currency, String
-    prop :balance_last_update, String
-    prop :limit, T.nilable(Integer)
+  class PlaidAccount < LunchMoney::DataObject
+    sig { returns(Integer) }
+    attr_accessor :id
+
+    sig { returns(String) }
+    attr_accessor :date_linked,
+      :name,
+      :type,
+      :mask,
+      :institution_name,
+      :status,
+      :last_import,
+      :balance,
+      :currency,
+      :balance_last_update
+
+    sig { returns(T.nilable(String)) }
+    attr_accessor :subtype
+
+    sig { returns(T.nilable(Integer)) }
+    attr_accessor :limit
+
+    sig do
+      params(
+        date_linked: String,
+        name: String,
+        type: String,
+        mask: String,
+        institution_name: String,
+        status: String,
+        last_import: String,
+        balance: String,
+        currency: String,
+        balance_last_update: String,
+        id: Integer,
+        limit: T.nilable(Integer),
+        subtype: T.nilable(String),
+      ).void
+    end
+    def initialize(date_linked:, name:, type:, mask:, institution_name:, status:, last_import:,
+      balance:, currency:, balance_last_update:, id:, limit: nil, subtype: nil)
+      super()
+      @date_linked = date_linked
+      @name = name
+      @type = type
+      @mask = mask
+      @institution_name = institution_name
+      @status = status
+      @last_import = last_import
+      @balance = balance
+      @currency = currency
+      @balance_last_update = balance_last_update
+      @id = id
+      @limit = limit
+      @subtype = subtype
+    end
   end
 end

--- a/lib/lunchmoney/plaid_accounts/plaid_account_calls.rb
+++ b/lib/lunchmoney/plaid_accounts/plaid_account_calls.rb
@@ -13,7 +13,7 @@ module LunchMoney
       return api_errors if api_errors.present?
 
       response.body[:plaid_accounts].map do |plaid_account|
-        LunchMoney::PlaidAccount.new(plaid_account)
+        LunchMoney::PlaidAccount.new(**plaid_account)
       end
     end
   end

--- a/lib/lunchmoney/recurring_expenses/recurring_expense.rb
+++ b/lib/lunchmoney/recurring_expenses/recurring_expense.rb
@@ -2,22 +2,59 @@
 # frozen_string_literal: true
 
 module LunchMoney
-  class RecurringExpense < T::Struct
-    prop :id, Integer
-    prop :start_date, T.nilable(String)
-    prop :end_date, T.nilable(String)
-    prop :cadence, String
-    prop :payee, String
-    prop :amount, Integer
-    prop :currency, String
-    prop :description, T.nilable(String)
-    prop :billing_date, String
-    prop :type, String
-    prop :original_name, T.nilable(String)
-    prop :source, String
-    prop :plaid_account_id, T.nilable(Integer)
-    prop :asset_id, T.nilable(Integer)
-    prop :transaction_id, T.nilable(Integer)
-    prop :category_id, T.nilable(Integer)
+  class RecurringExpense < LunchMoney::DataObject
+    sig { returns(Integer) }
+    attr_accessor :id, :amount
+
+    sig { returns(T.nilable(String)) }
+    attr_accessor :start_date, :end_date, :description, :original_name
+
+    sig { returns(String) }
+    attr_accessor :cadence, :payee, :currency, :billing_date, :type, :source
+
+    sig { returns(T.nilable(Integer)) }
+    attr_accessor :plaid_account_id, :asset_id, :transaction_id, :category_id
+
+    sig do
+      params(
+        cadence: String,
+        payee: String,
+        amount: Integer,
+        currency: String,
+        billing_date: String,
+        type: String,
+        source: String,
+        id: Integer,
+        category_id: T.nilable(Integer),
+        start_date: T.nilable(String),
+        end_date: T.nilable(String),
+        description: T.nilable(String),
+        original_name: T.nilable(String),
+        plaid_account_id: T.nilable(Integer),
+        asset_id: T.nilable(Integer),
+        transaction_id: T.nilable(Integer),
+      ).void
+    end
+    def initialize(cadence:, payee:, amount:, currency:, billing_date:, type:, source:, id:, category_id: nil,
+      start_date: nil, end_date: nil, description: nil, original_name: nil, plaid_account_id: nil, asset_id: nil,
+      transaction_id: nil)
+      super()
+      @cadence = cadence
+      @payee = payee
+      @amount = amount
+      @currency = currency
+      @billing_date = billing_date
+      @type = type
+      @source = source
+      @id = id
+      @category_id = category_id
+      @start_date = start_date
+      @end_date = end_date
+      @description = description
+      @original_name = original_name
+      @plaid_account_id = plaid_account_id
+      @asset_id = asset_id
+      @transaction_id = transaction_id
+    end
   end
 end

--- a/lib/lunchmoney/recurring_expenses/recurring_expense_calls.rb
+++ b/lib/lunchmoney/recurring_expenses/recurring_expense_calls.rb
@@ -27,7 +27,9 @@ module LunchMoney
       api_errors = errors(response)
       return api_errors if api_errors.present?
 
-      response.body[:recurring_expenses].map { |recurring_expense| LunchMoney::RecurringExpense.new(recurring_expense) }
+      response.body[:recurring_expenses].map do |recurring_expense|
+        LunchMoney::RecurringExpense.new(**recurring_expense)
+      end
     end
   end
 end

--- a/lib/lunchmoney/tags/tag.rb
+++ b/lib/lunchmoney/tags/tag.rb
@@ -2,10 +2,26 @@
 # frozen_string_literal: true
 
 module LunchMoney
-  class Tag < T::Struct
-    prop :id, Integer
-    prop :name, String
-    prop :description, T.nilable(String)
-    prop :archived, T::Boolean, default: false
+  class Tag < LunchMoney::DataObject
+    sig { returns(Integer) }
+    attr_accessor :id
+
+    sig { returns(String) }
+    attr_accessor :name
+
+    sig { returns(T.nilable(String)) }
+    attr_accessor :description
+
+    sig { returns(T::Boolean) }
+    attr_accessor :archived
+
+    sig { params(id: Integer, name: String, archived: T::Boolean, description: T.nilable(String)).void }
+    def initialize(id:, name:, archived:, description: nil)
+      super()
+      @id = id
+      @name = name
+      @archived = archived
+      @description = description
+    end
   end
 end

--- a/lib/lunchmoney/tags/tag_calls.rb
+++ b/lib/lunchmoney/tags/tag_calls.rb
@@ -12,7 +12,7 @@ module LunchMoney
       api_errors = errors(response)
       return api_errors if api_errors.present?
 
-      response.body.map { |tag| LunchMoney::Tag.new(tag) }
+      response.body.map { |tag| LunchMoney::Tag.new(**tag) }
     end
   end
 end

--- a/lib/lunchmoney/transactions/split.rb
+++ b/lib/lunchmoney/transactions/split.rb
@@ -2,11 +2,32 @@
 # frozen_string_literal: true
 
 module LunchMoney
-  class Split < T::Struct
-    prop :payee, T.nilable(String)
-    prop :date, T.nilable(String)
-    prop :category_id, T.nilable(Integer)
-    prop :notes, T.nilable(String)
-    prop :amount, T.any(Integer, String)
+  class Split < LunchMoney::DataObject
+    sig { returns(T.nilable(String)) }
+    attr_accessor :payee, :date, :notes
+
+    sig { returns(T.nilable(Integer)) }
+    attr_accessor :category_id
+
+    sig { returns(T.any(Integer, String)) }
+    attr_accessor :amount
+
+    sig do
+      params(
+        amount: T.any(Integer, String),
+        payee: T.nilable(String),
+        date: T.nilable(String),
+        category_id: T.nilable(Integer),
+        notes: T.nilable(String),
+      ).void
+    end
+    def initialize(amount:, payee: nil, date: nil, category_id: nil, notes: nil)
+      super()
+      @amount = amount
+      @payee = payee
+      @date = date
+      @category_id = category_id
+      @notes = notes
+    end
   end
 end

--- a/lib/lunchmoney/transactions/transaction.rb
+++ b/lib/lunchmoney/transactions/transaction.rb
@@ -2,29 +2,86 @@
 # frozen_string_literal: true
 
 module LunchMoney
-  class Transaction < T::Struct
-    prop :id, T.nilable(Integer)
-    prop :date, T.nilable(String)
-    prop :payee, T.nilable(String)
-    prop :amount, T.nilable(String)
-    prop :currency, T.nilable(String)
-    prop :to_base, T.nilable(Integer)
-    prop :notes, T.nilable(String)
-    prop :category_id, T.nilable(Integer)
-    prop :recurring_id, T.nilable(Integer)
-    prop :asset_id, T.nilable(Integer)
-    prop :plaid_account_id, T.nilable(Integer)
-    prop :status, T.nilable(String)
-    prop :parent_id, T.nilable(Integer)
-    prop :is_group, T.nilable(T::Boolean)
-    prop :group_id, T.nilable(Integer)
-    prop :tags, T.nilable(T::Array[LunchMoney::Tag])
-    prop :external_id, T.nilable(String)
-    prop :original_name, T.nilable(String)
-    prop :type, T.nilable(String)
-    prop :subtype, T.nilable(String)
-    prop :fees, T.nilable(String)
-    prop :price, T.nilable(String)
-    prop :quantity, T.nilable(String)
+  class Transaction < LunchMoney::DataObject
+    sig { returns(T.nilable(Integer)) }
+    attr_accessor :id, :to_base, :category_id, :recurring_id, :asset_id, :plaid_account_id, :parent_id, :group_id
+
+    sig { returns(T.nilable(String)) }
+    attr_accessor :date,
+      :payee,
+      :amount,
+      :currency,
+      :notes,
+      :status,
+      :external_id,
+      :original_name,
+      :type,
+      :subtype,
+      :fees,
+      :price,
+      :quantity
+
+    sig { returns(T.nilable(T::Boolean)) }
+    attr_accessor :is_group
+
+    sig { returns(T.nilable(T::Array[LunchMoney::Tag])) }
+    attr_accessor :tags
+
+    sig do
+      params(
+        quantity: T.nilable(String),
+        date: T.nilable(String),
+        payee: T.nilable(String),
+        amount: T.nilable(String),
+        currency: T.nilable(String),
+        to_base: T.nilable(Integer),
+        notes: T.nilable(String),
+        category_id: T.nilable(Integer),
+        recurring_id: T.nilable(Integer),
+        asset_id: T.nilable(Integer),
+        plaid_account_id: T.nilable(Integer),
+        status: T.nilable(String),
+        parent_id: T.nilable(Integer),
+        is_group: T.nilable(T::Boolean),
+        group_id: T.nilable(Integer),
+        tags: T.nilable(T::Array[LunchMoney::Tag]),
+        external_id: T.nilable(String),
+        original_name: T.nilable(String),
+        type: T.nilable(String),
+        subtype: T.nilable(String),
+        fees: T.nilable(String),
+        price: T.nilable(String),
+        id: T.nilable(Integer),
+      ).void
+    end
+    def initialize(quantity: nil, date: nil, payee: nil, amount: nil, currency: nil, to_base: nil, notes: nil,
+      category_id: nil, recurring_id: nil, asset_id: nil, plaid_account_id: nil, status: nil, parent_id: nil,
+      is_group: nil, group_id: nil, tags: nil, external_id: nil, original_name: nil, type: nil, subtype: nil,
+      fees: nil, price: nil, id: nil)
+      super()
+      @quantity = quantity
+      @date = date
+      @payee = payee
+      @amount = amount
+      @currency = currency
+      @to_base = to_base
+      @notes = notes
+      @category_id = category_id
+      @recurring_id = recurring_id
+      @asset_id = asset_id
+      @plaid_account_id = plaid_account_id
+      @status = status
+      @parent_id = parent_id
+      @is_group = is_group
+      @group_id = group_id
+      @tags = tags
+      @external_id = external_id
+      @original_name = original_name
+      @type = type
+      @subtype = subtype
+      @fees = fees
+      @price = price
+      @id = id
+    end
   end
 end

--- a/lib/lunchmoney/transactions/transaction_calls.rb
+++ b/lib/lunchmoney/transactions/transaction_calls.rb
@@ -72,7 +72,7 @@ module LunchMoney
       response.body[:transactions].map do |transaction|
         transaction[:tags]&.map! { |tag| LunchMoney::Tag.new(tag) }
 
-        LunchMoney::Transaction.new(transaction)
+        LunchMoney::Transaction.new(**transaction)
       end
     end
 
@@ -97,7 +97,7 @@ module LunchMoney
       api_errors = errors(response)
       return api_errors if api_errors.present?
 
-      LunchMoney::Transaction.new(response.body)
+      LunchMoney::Transaction.new(**response.body)
     end
 
     sig do

--- a/lib/lunchmoney/transactions/update_transaction.rb
+++ b/lib/lunchmoney/transactions/update_transaction.rb
@@ -2,17 +2,45 @@
 # frozen_string_literal: true
 
 module LunchMoney
-  class UpdateTransaction < T::Struct
-    prop :date, T.nilable(String)
-    prop :category_id, T.nilable(Integer)
-    prop :payee, T.nilable(String)
-    prop :amount, T.nilable(String)
-    prop :currency, T.nilable(String)
-    prop :asset_id, T.nilable(Integer)
-    prop :recurring_id, T.nilable(Integer)
-    prop :notes, T.nilable(String)
-    prop :status, T.nilable(String)
-    prop :external_id, T.nilable(String)
-    prop :tags, T.nilable(T::Array[T.any(String, Integer)])
+  class UpdateTransaction < LunchMoney::DataObject
+    sig { returns(T.nilable(String)) }
+    attr_accessor :date, :payee, :amount, :currency, :notes, :status, :external_id
+
+    sig { returns(T.nilable(Integer)) }
+    attr_accessor :category_id, :asset_id, :recurring_id
+
+    sig { returns(T.nilable(T::Array[T.any(String, Integer)])) }
+    attr_accessor :tags
+
+    sig do
+      params(
+        tags: T.nilable(T::Array[T.any(String, Integer)]),
+        category_id: T.nilable(Integer),
+        payee: T.nilable(String),
+        amount: T.nilable(String),
+        currency: T.nilable(String),
+        asset_id: T.nilable(Integer),
+        recurring_id: T.nilable(Integer),
+        notes: T.nilable(String),
+        status: T.nilable(String),
+        external_id: T.nilable(String),
+        date: T.nilable(String),
+      ).void
+    end
+    def initialize(tags: nil, category_id: nil, payee: nil, amount: nil, currency: nil, asset_id: nil,
+      recurring_id: nil, notes: nil, status: nil, external_id: nil, date: nil)
+      super()
+      @tags = tags
+      @category_id = category_id
+      @payee = payee
+      @amount = amount
+      @currency = currency
+      @asset_id = asset_id
+      @recurring_id = recurring_id
+      @notes = notes
+      @status = status
+      @external_id = external_id
+      @date = date
+    end
   end
 end

--- a/lib/lunchmoney/user/user.rb
+++ b/lib/lunchmoney/user/user.rb
@@ -2,12 +2,34 @@
 # frozen_string_literal: true
 
 module LunchMoney
-  class User < T::Struct
-    prop :user_id, Integer
-    prop :user_name, String
-    prop :user_email, String
-    prop :account_id, Integer
-    prop :budget_name, String
-    prop :api_key_label, T.nilable(String)
+  class User < LunchMoney::DataObject
+    sig { returns(Integer) }
+    attr_accessor :user_id, :account_id
+
+    sig { returns(String) }
+    attr_accessor :user_name, :user_email, :budget_name
+
+    sig { returns(T.nilable(String)) }
+    attr_accessor :api_key_label
+
+    sig do
+      params(
+        user_id: Integer,
+        user_name: String,
+        user_email: String,
+        account_id: Integer,
+        budget_name: String,
+        api_key_label: T.nilable(String),
+      ).void
+    end
+    def initialize(user_id:, user_name:, user_email:, account_id:, budget_name:, api_key_label: nil)
+      super()
+      @user_id = user_id
+      @user_name = user_name
+      @user_email = user_email
+      @account_id = account_id
+      @budget_name = budget_name
+      @api_key_label = api_key_label
+    end
   end
 end

--- a/lib/lunchmoney/user/user_calls.rb
+++ b/lib/lunchmoney/user/user_calls.rb
@@ -12,7 +12,7 @@ module LunchMoney
       api_errors = errors(response)
       return api_errors if api_errors.present?
 
-      LunchMoney::User.new(response.body)
+      LunchMoney::User.new(**response.body)
     end
   end
 end

--- a/test/helpers/mocha_typed.rb
+++ b/test/helpers/mocha_typed.rb
@@ -5,7 +5,6 @@ module Mocha
   # Extension for Mocha Mocks to make them play well with sorbet.
   module Typed
     include(Kernel)
-    extend(T::Sig)
     extend(T::Helpers)
 
     requires_ancestor { Mocha::API }


### PR DESCRIPTION
Following https://github.com/Shopify/rubocop-sorbet/pull/178#issuecomment-1739924189 and switching away from `T::Struct`