### PR TITLE
restrict remote ci tests to mainly GET type requests

### DIFF
--- a/test/helpers/vcr_helper.rb
+++ b/test/helpers/vcr_helper.rb
@@ -1,6 +1,22 @@
 # typed: strict
 # frozen_string_literal: true
 
+module VcrHelper
+  sig { params(block: T.proc.void).void }
+  def with_real_ci_connections(&block)
+    if ENV.fetch("REMOTE_TESTS_ENABLED", nil)
+      VCR.turned_off(ignore_cassettes: true) do
+        WebMock.enable_net_connect!
+        block.call
+      end
+    else
+      yield
+    end
+  ensure
+    WebMock.disable_net_connect!
+  end
+end
+
 VCR.configure do |config|
   config.cassette_library_dir = "test/cassettes"
   config.hook_into(:webmock)
@@ -26,20 +42,4 @@ VCR.configure do |config|
       response["user_email"]
     end
   end
-
-  config.allow_http_connections_when_no_cassette = true if ENV.fetch("VCR_RECORD", nil)
-end
-
-if ENV.fetch("REMOTE_TESTS_ENABLED", nil)
-  puts "Remote tests are enabled, ignoring VCR cassettes and enabling real HTTP connections"
-  VCR.turn_off!(ignore_cassettes: true)
-  WebMock.enable_net_connect!
-elsif ENV.fetch("VCR_RECORD", nil)
-  puts "VCR recording is enabled, recording VCR cassettes and enabling real HTTP connections"
-  VCR.turn_on!
-  WebMock.enable_net_connect!
-else
-  puts "Remote tests are disabled, using VCR cassettes and disabling real HTTP connections"
-  VCR.turn_on!
-  WebMock.disable_net_connect!
 end

--- a/test/lunchmoney/assets/asset_calls_test.rb
+++ b/test/lunchmoney/assets/asset_calls_test.rb
@@ -7,11 +7,13 @@ class AssetCallsTest < ActiveSupport::TestCase
   include MockResponseHelper
 
   test "assets returns an array of Asset objects on success response" do
-    VCR.use_cassette("assets/assets_success") do
-      api_call = LunchMoney::AssetCalls.new.assets
+    with_real_ci_connections do
+      VCR.use_cassette("assets/assets_success") do
+        api_call = LunchMoney::AssetCalls.new.assets
 
-      api_call.each do |asset|
-        assert_kind_of(LunchMoney::Asset, asset)
+        api_call.each do |asset|
+          assert_kind_of(LunchMoney::Asset, asset)
+        end
       end
     end
   end

--- a/test/lunchmoney/assets/asset_calls_test.rb
+++ b/test/lunchmoney/assets/asset_calls_test.rb
@@ -5,6 +5,7 @@ require "test_helper"
 
 class AssetCallsTest < ActiveSupport::TestCase
   include MockResponseHelper
+  include VcrHelper
 
   test "assets returns an array of Asset objects on success response" do
     with_real_ci_connections do

--- a/test/lunchmoney/budget/budget_calls_test.rb
+++ b/test/lunchmoney/budget/budget_calls_test.rb
@@ -5,6 +5,7 @@ require "test_helper"
 
 class BudgetCallsTest < ActiveSupport::TestCase
   include MockResponseHelper
+  include VcrHelper
 
   test "budgets returns an array of Budget objects on success response" do
     with_real_ci_connections do

--- a/test/lunchmoney/budget/budget_calls_test.rb
+++ b/test/lunchmoney/budget/budget_calls_test.rb
@@ -7,10 +7,12 @@ class BudgetCallsTest < ActiveSupport::TestCase
   include MockResponseHelper
 
   test "budgets returns an array of Budget objects on success response" do
-    VCR.use_cassette("budget/budgets_success") do
-      api_call = LunchMoney::BudgetCalls.new.budgets(start_date: "2023-01-01", end_date: "2024-01-01")
+    with_real_ci_connections do
+      VCR.use_cassette("budget/budgets_success") do
+        api_call = LunchMoney::BudgetCalls.new.budgets(start_date: "2023-01-01", end_date: "2024-01-01")
 
-      assert_kind_of(LunchMoney::Budget, api_call.first)
+        assert_kind_of(LunchMoney::Budget, api_call.first)
+      end
     end
   end
 

--- a/test/lunchmoney/categories/category_calls_test.rb
+++ b/test/lunchmoney/categories/category_calls_test.rb
@@ -7,11 +7,13 @@ class CategoryCallsTest < ActiveSupport::TestCase
   include MockResponseHelper
 
   test "categories returns an array of Category objects on success response" do
-    VCR.use_cassette("categories/categories_success") do
-      api_call = LunchMoney::CategoryCalls.new.categories
+    with_real_ci_connections do
+      VCR.use_cassette("categories/categories_success") do
+        api_call = LunchMoney::CategoryCalls.new.categories
 
-      api_call.each do |category|
-        assert_kind_of(LunchMoney::Category, category)
+        api_call.each do |category|
+          assert_kind_of(LunchMoney::Category, category)
+        end
       end
     end
   end
@@ -28,21 +30,25 @@ class CategoryCallsTest < ActiveSupport::TestCase
   end
 
   test "categories does not raise an error when called with flattened format" do
-    query_params = { format: "flattened" }
+    with_real_ci_connections do
+      query_params = { format: "flattened" }
 
-    VCR.use_cassette("categories/categories_flattened_success") do
-      assert_nothing_raised do
-        LunchMoney::CategoryCalls.new.categories(**query_params)
+      VCR.use_cassette("categories/categories_flattened_success") do
+        assert_nothing_raised do
+          LunchMoney::CategoryCalls.new.categories(**query_params)
+        end
       end
     end
   end
 
   test "categories does not raise an error when called with nested format" do
-    query_params = { format: "nested" }
+    with_real_ci_connections do
+      query_params = { format: "nested" }
 
-    VCR.use_cassette("categories/categories_nested_success") do
-      assert_nothing_raised do
-        LunchMoney::CategoryCalls.new.categories(**query_params)
+      VCR.use_cassette("categories/categories_nested_success") do
+        assert_nothing_raised do
+          LunchMoney::CategoryCalls.new.categories(**query_params)
+        end
       end
     end
   end
@@ -58,27 +64,33 @@ class CategoryCallsTest < ActiveSupport::TestCase
   end
 
   test "category returns a Category object on success response with regular category" do
-    VCR.use_cassette("categories/category_category_success") do
-      api_call = LunchMoney::CategoryCalls.new.category(777052)
+    with_real_ci_connections do
+      VCR.use_cassette("categories/category_category_success") do
+        api_call = LunchMoney::CategoryCalls.new.category(777052)
 
-      assert_kind_of(LunchMoney::Category, api_call)
+        assert_kind_of(LunchMoney::Category, api_call)
+      end
     end
   end
 
   test "category returns a Category object on success response with category group" do
-    VCR.use_cassette("categories/category_category_group_success") do
-      api_call = LunchMoney::CategoryCalls.new.category(777021)
+    with_real_ci_connections do
+      VCR.use_cassette("categories/category_category_group_success") do
+        api_call = LunchMoney::CategoryCalls.new.category(777021)
 
-      assert_kind_of(LunchMoney::Category, api_call)
+        assert_kind_of(LunchMoney::Category, api_call)
+      end
     end
   end
 
   test "category returns an array of Error objects on error response" do
-    VCR.use_cassette("categories/category_does_not_exist_failure") do
-      api_call = LunchMoney::CategoryCalls.new.category(1)
+    with_real_ci_connections do
+      VCR.use_cassette("categories/category_does_not_exist_failure") do
+        api_call = LunchMoney::CategoryCalls.new.category(1)
 
-      T.unsafe(api_call).each do |error|
-        assert_kind_of(LunchMoney::Error, error)
+        T.unsafe(api_call).each do |error|
+          assert_kind_of(LunchMoney::Error, error)
+        end
       end
     end
   end

--- a/test/lunchmoney/categories/category_calls_test.rb
+++ b/test/lunchmoney/categories/category_calls_test.rb
@@ -5,6 +5,7 @@ require "test_helper"
 
 class CategoryCallsTest < ActiveSupport::TestCase
   include MockResponseHelper
+  include VcrHelper
 
   test "categories returns an array of Category objects on success response" do
     with_real_ci_connections do

--- a/test/lunchmoney/crypto/crypto_calls_test.rb
+++ b/test/lunchmoney/crypto/crypto_calls_test.rb
@@ -7,11 +7,13 @@ class CryptoCallsTest < ActiveSupport::TestCase
   include MockResponseHelper
 
   test "crypto returns an array of Crypto objects on success response" do
-    VCR.use_cassette("crypto/crypto_success") do
-      api_call = LunchMoney::CryptoCalls.new.crypto
+    with_real_ci_connections do
+      VCR.use_cassette("crypto/crypto_success") do
+        api_call = LunchMoney::CryptoCalls.new.crypto
 
-      api_call.each do |crypto|
-        assert_kind_of(LunchMoney::Crypto, crypto)
+        api_call.each do |crypto|
+          assert_kind_of(LunchMoney::Crypto, crypto)
+        end
       end
     end
   end

--- a/test/lunchmoney/crypto/crypto_calls_test.rb
+++ b/test/lunchmoney/crypto/crypto_calls_test.rb
@@ -5,6 +5,7 @@ require "test_helper"
 
 class CryptoCallsTest < ActiveSupport::TestCase
   include MockResponseHelper
+  include VcrHelper
 
   test "crypto returns an array of Crypto objects on success response" do
     with_real_ci_connections do

--- a/test/lunchmoney/plaid_accounts/plaid_account_calls_test.rb
+++ b/test/lunchmoney/plaid_accounts/plaid_account_calls_test.rb
@@ -5,6 +5,7 @@ require "test_helper"
 
 class PlaidAccountCallsTest < ActiveSupport::TestCase
   include MockResponseHelper
+  include VcrHelper
 
   test "plaid_accounts returns an array of PlaidAccount objects on success response" do
     with_real_ci_connections do

--- a/test/lunchmoney/plaid_accounts/plaid_account_calls_test.rb
+++ b/test/lunchmoney/plaid_accounts/plaid_account_calls_test.rb
@@ -7,11 +7,13 @@ class PlaidAccountCallsTest < ActiveSupport::TestCase
   include MockResponseHelper
 
   test "plaid_accounts returns an array of PlaidAccount objects on success response" do
-    VCR.use_cassette("plaid_accounts/plaid_accounts_success") do
-      api_call = LunchMoney::PlaidAccountCalls.new.plaid_accounts
+    with_real_ci_connections do
+      VCR.use_cassette("plaid_accounts/plaid_accounts_success") do
+        api_call = LunchMoney::PlaidAccountCalls.new.plaid_accounts
 
-      api_call.each do |plaid_account|
-        assert_kind_of(LunchMoney::PlaidAccount, plaid_account)
+        api_call.each do |plaid_account|
+          assert_kind_of(LunchMoney::PlaidAccount, plaid_account)
+        end
       end
     end
   end
@@ -28,10 +30,12 @@ class PlaidAccountCallsTest < ActiveSupport::TestCase
   end
 
   test "plaid_accounts_fetch returns a boolean response on success" do
-    VCR.use_cassette("plaid_accounts/plaid_accounts_fetch_success") do
-      api_call = LunchMoney::PlaidAccountCalls.new.plaid_accounts_fetch
+    with_real_ci_connections do
+      VCR.use_cassette("plaid_accounts/plaid_accounts_fetch_success") do
+        api_call = LunchMoney::PlaidAccountCalls.new.plaid_accounts_fetch
 
-      assert_includes([TrueClass, FalseClass], api_call.class)
+        assert_includes([TrueClass, FalseClass], api_call.class)
+      end
     end
   end
 

--- a/test/lunchmoney/recurring_expenses/recurring_expense_calls_test.rb
+++ b/test/lunchmoney/recurring_expenses/recurring_expense_calls_test.rb
@@ -5,6 +5,7 @@ require "test_helper"
 
 class RecurringExpenseCallsTest < ActiveSupport::TestCase
   include MockResponseHelper
+  include VcrHelper
 
   test "recurring_expenses returns an array of Tag objects on success response" do
     with_real_ci_connections do

--- a/test/lunchmoney/recurring_expenses/recurring_expense_calls_test.rb
+++ b/test/lunchmoney/recurring_expenses/recurring_expense_calls_test.rb
@@ -7,11 +7,13 @@ class RecurringExpenseCallsTest < ActiveSupport::TestCase
   include MockResponseHelper
 
   test "recurring_expenses returns an array of Tag objects on success response" do
-    VCR.use_cassette("recurring_expenses/recurring_expenses_success") do
-      api_call = LunchMoney::RecurringExpenseCalls.new.recurring_expenses
+    with_real_ci_connections do
+      VCR.use_cassette("recurring_expenses/recurring_expenses_success") do
+        api_call = LunchMoney::RecurringExpenseCalls.new.recurring_expenses
 
-      api_call.each do |recurring_expense|
-        assert_kind_of(LunchMoney::RecurringExpense, recurring_expense)
+        api_call.each do |recurring_expense|
+          assert_kind_of(LunchMoney::RecurringExpense, recurring_expense)
+        end
       end
     end
   end

--- a/test/lunchmoney/tags/tag_calls_test.rb
+++ b/test/lunchmoney/tags/tag_calls_test.rb
@@ -7,11 +7,13 @@ class TagCallsTest < ActiveSupport::TestCase
   include MockResponseHelper
 
   test "tags returns an array of Tag objects on success response" do
-    VCR.use_cassette("tags/tags_success") do
-      api_call = LunchMoney::TagCalls.new.tags
+    with_real_ci_connections do
+      VCR.use_cassette("tags/tags_success") do
+        api_call = LunchMoney::TagCalls.new.tags
 
-      api_call.each do |tag|
-        assert_kind_of(LunchMoney::Tag, tag)
+        api_call.each do |tag|
+          assert_kind_of(LunchMoney::Tag, tag)
+        end
       end
     end
   end

--- a/test/lunchmoney/tags/tag_calls_test.rb
+++ b/test/lunchmoney/tags/tag_calls_test.rb
@@ -5,6 +5,7 @@ require "test_helper"
 
 class TagCallsTest < ActiveSupport::TestCase
   include MockResponseHelper
+  include VcrHelper
 
   test "tags returns an array of Tag objects on success response" do
     with_real_ci_connections do

--- a/test/lunchmoney/transactions/transaction_calls_test.rb
+++ b/test/lunchmoney/transactions/transaction_calls_test.rb
@@ -7,11 +7,13 @@ class TransactionCallsTest < ActiveSupport::TestCase
   include MockResponseHelper
 
   test "transactions returns an array of Transaction objects on success response" do
-    VCR.use_cassette("transactions/transactions_success") do
-      api_call = LunchMoney::TransactionCalls.new.transactions(start_date: "2019-01-01", end_date: "2025-01-01")
+    with_real_ci_connections do
+      VCR.use_cassette("transactions/transactions_success") do
+        api_call = LunchMoney::TransactionCalls.new.transactions(start_date: "2019-01-01", end_date: "2025-01-01")
 
-      api_call.each do |transaction|
-        assert_kind_of(LunchMoney::Transaction, transaction)
+        api_call.each do |transaction|
+          assert_kind_of(LunchMoney::Transaction, transaction)
+        end
       end
     end
   end
@@ -28,10 +30,12 @@ class TransactionCallsTest < ActiveSupport::TestCase
   end
 
   test "transaction returns a Transaction objects on success response" do
-    VCR.use_cassette("transactions/transaction_success") do
-      api_call = LunchMoney::TransactionCalls.new.transaction(893631800)
+    with_real_ci_connections do
+      VCR.use_cassette("transactions/transaction_success") do
+        api_call = LunchMoney::TransactionCalls.new.transaction(893631800)
 
-      assert_kind_of(LunchMoney::Transaction, api_call)
+        assert_kind_of(LunchMoney::Transaction, api_call)
+      end
     end
   end
 
@@ -47,10 +51,12 @@ class TransactionCallsTest < ActiveSupport::TestCase
   end
 
   test "transaction_group returns a Transaction objects on success response" do
-    VCR.use_cassette("transactions/transaction_group_success") do
-      api_call = LunchMoney::TransactionCalls.new.transaction(894063595)
+    with_real_ci_connections do
+      VCR.use_cassette("transactions/transaction_group_success") do
+        api_call = LunchMoney::TransactionCalls.new.transaction(894063595)
 
-      assert_kind_of(LunchMoney::Transaction, api_call)
+        assert_kind_of(LunchMoney::Transaction, api_call)
+      end
     end
   end
 
@@ -66,14 +72,16 @@ class TransactionCallsTest < ActiveSupport::TestCase
   end
 
   test "insert_transactions returns a hash containing an array of ids on success response" do
-    VCR.use_cassette("transactions/insert_transactions_success") do
-      api_call = LunchMoney::TransactionCalls.new.insert_transactions([random_update_transaction])
-      ids = T.cast(api_call, T::Hash[Symbol, T::Array[Integer]])[:ids]
+    with_real_ci_connections do
+      VCR.use_cassette("transactions/insert_transactions_success") do
+        api_call = LunchMoney::TransactionCalls.new.insert_transactions([random_update_transaction])
+        ids = T.cast(api_call, T::Hash[Symbol, T::Array[Integer]])[:ids]
 
-      refute_nil(ids)
+        refute_nil(ids)
 
-      T.unsafe(ids).each do |id|
-        assert_kind_of(Integer, id)
+        T.unsafe(ids).each do |id|
+          assert_kind_of(Integer, id)
+        end
       end
     end
   end

--- a/test/lunchmoney/transactions/transaction_calls_test.rb
+++ b/test/lunchmoney/transactions/transaction_calls_test.rb
@@ -5,6 +5,7 @@ require "test_helper"
 
 class TransactionCallsTest < ActiveSupport::TestCase
   include MockResponseHelper
+  include VcrHelper
 
   test "transactions returns an array of Transaction objects on success response" do
     with_real_ci_connections do

--- a/test/lunchmoney/user/user_calls_test.rb
+++ b/test/lunchmoney/user/user_calls_test.rb
@@ -7,10 +7,12 @@ class UserCallsTest < ActiveSupport::TestCase
   include MockResponseHelper
 
   test "me returns a User objects on success response" do
-    VCR.use_cassette("user/me_success") do
-      api_call = LunchMoney::UserCalls.new.me
+    with_real_ci_connections do
+      VCR.use_cassette("user/me_success") do
+        api_call = LunchMoney::UserCalls.new.me
 
-      assert_kind_of(LunchMoney::User, api_call)
+        assert_kind_of(LunchMoney::User, api_call)
+      end
     end
   end
 

--- a/test/lunchmoney/user/user_calls_test.rb
+++ b/test/lunchmoney/user/user_calls_test.rb
@@ -5,6 +5,7 @@ require "test_helper"
 
 class UserCallsTest < ActiveSupport::TestCase
   include MockResponseHelper
+  include VcrHelper
 
   test "me returns a User objects on success response" do
     with_real_ci_connections do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -18,3 +18,5 @@ require_relative "helpers/configuration_helper"
 require_relative "helpers/mocha_typed"
 require_relative "helpers/mock_response_helper"
 require_relative "helpers/vcr_helper"
+
+include VcrHelper

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -18,5 +18,3 @@ require_relative "helpers/configuration_helper"
 require_relative "helpers/mocha_typed"
 require_relative "helpers/mock_response_helper"
 require_relative "helpers/vcr_helper"
-
-include VcrHelper


### PR DESCRIPTION
Since future calls that modify or delete data are tricky to set up in a way that allows for consistent remote tests I've wrapped the existing tests that work well with remote CI tests with a new `with_real_ci_connections` helper. 